### PR TITLE
add `Sports event` category so airings will be considered sporting ev…

### DIFF
--- a/services/generate-xmltv.ts
+++ b/services/generate-xmltv.ts
@@ -26,7 +26,7 @@ const formatEntryName = (entry: IEntry) => {
 };
 
 const formatCategories = (categories: string[] = []) =>
-  _.uniq(['Sports', 'HD', ...categories]).map(category => ({
+  _.uniq(['Sports', 'Sports event', 'HD', ...categories]).map(category => ({
     category: [
       {
         _attr: {


### PR DESCRIPTION
Channels only considers airings tagged with `Sports event` as live sports. Only airings with this tag will show up in the Sports channel collection that's built into the client, or if users edit their own Channel Collection to include Sports.

This change adds `Sports event` so that airings from EPlusTV can be considered live sports.